### PR TITLE
Handle unknown report types correctly

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,4 @@ travis-ci = { repository="dcreager/rs-reporting-api" }
 
 [dependencies]
 serde = { version="^1.0", features=["derive"] }
-typetag = "^0.1"
-
-[dev-dependencies]
 serde_json = "^1.0"


### PR DESCRIPTION
Before if you parsed a vector of reports, _any_ unknown report type would result in a parse error that threw the entire result vector away. This patch simplifies things, throwing away all of the `Any`-based
shenanigans.  When parsing, we just stash the body away into a JSON value.  Later on, when you're trying to operate on a particular kind of report, we try to parse the body using that report type's schema.